### PR TITLE
fix: corrigir KeyError da coluna 'devolvido' no DataFrame de investid…

### DIFF
--- a/sistema_caixa.py
+++ b/sistema_caixa.py
@@ -911,8 +911,16 @@ with abas[1]:
                     st.dataframe(df_investidores, use_container_width=True)
 
                     # Gráfico de barras para status de devolução
-                    status_devolucao = df_investidores["devolvido"].value_counts(
-                    )
+                    # Verificar se a coluna existe antes de acessar
+                    if "devolvido" in df_investidores.columns:
+                        status_devolucao = df_investidores["devolvido"].value_counts(
+                        )
+                    else:
+                        st.error(
+                            "Coluna 'devolvido' não encontrada. Colunas disponíveis:")
+                        st.write(df_investidores.columns.tolist())
+                        status_devolucao = pd.Series()  # série vazia para evitar erro
+
                     if not status_devolucao.empty:
                         status_devolucao.index = status_devolucao.index.map(
                             {True: 'Devolvido', False: 'Pendente'})


### PR DESCRIPTION
## Correção de KeyError na coluna 'devolvido'

**Problema:** O aplicativo apresentava erro `KeyError` ao tentar acessar a coluna 'devolvido' que não existia no DataFrame.

**Solução implementada:**
- ✅ Adicionada verificação de existência da coluna antes do acesso
- ✅ Implementado fallback seguro para evitar erros
- ✅ Adicionado debug para visualização das colunas disponíveis

**Testes realizados:** 
- Aplicação funciona sem erros
- Compatibilidade mantida com estrutura existente